### PR TITLE
[WIP - don't merge] Cython example 1

### DIFF
--- a/PythonExamples/Instructions.MD
+++ b/PythonExamples/Instructions.MD
@@ -1,0 +1,24 @@
+# Execute the example file
+- Compile ROPTLIB as a library
+    - ```make libropt.so```
+- Copy libropt.so into PythonExamples folder
+- Compile Cython
+    - ```python setup2.py build_ext --inplace```
+- Use in Python
+    ```
+    from PySimpleExample import py_simple_example
+    result = py_simple_example()
+     ```
+
+# Create out your own code for using existing 
+- These instructions assume that
+    - you want to use one of the existing problems (cost function + gradient + option Hessian).
+    - all  you need to do is to combine existing ROPTLIB objects in a particular combination of problem+solver+parameters and, perhaps, add some user defined code.
+- Steps:
+    - Make sure that all the classes and methods that you need are included in libropt.pxd. Use existing file as template.
+    - Write your Cython wrapper in a .pyx file. You can ese PySimpleExample.pyx as a template. The wrapper will provide the connection between ROPTLIB C++ code and Python.
+    - Compile your wrapper.
+    - Use from Python.
+
+
+

--- a/PythonExamples/PySimpleExample.pyx
+++ b/PythonExamples/PySimpleExample.pyx
@@ -1,0 +1,83 @@
+# distutils: language = c++
+
+
+from libropt cimport StieVariable
+from libropt cimport  Stiefel, StieBrockett, RTRNewton, DEBUGINFO, FINALRESULT
+from libropt cimport genrandseed, genrandnormal
+import numpy as np
+
+cdef int py_simple_example():
+    # // choose a random seed based on current clock
+    genrandseed(0)
+
+    # // size of the Stiefel manifold
+    cdef int n = 12
+    cdef p = 8
+    cdef int i, j
+    # // Generate the matrices in the Brockett problem.
+    # cdef double *B = new double[n * n + p]
+    B = np.zeros(n * n + p)
+    cdef double[::1] arr_B = B
+    # B = new double[n * n + p]
+    # cdef double *D = B + n * n
+    # D = &B[n**2]
+    D = B[n**2:]
+    cdef double[::1] arr_D = D
+    # for i in range(n):
+    #     for j in range(i, n):
+    #         B[i + j * n] = genrandnormal()
+    #         B[j + i * n] = B[i + j * n]
+    #
+    # for i in range(p):
+    #     D[i] = static_cast<double> (i + 1)
+    for i in range(n):
+        for j in range(i, n):
+            arr_B[i + j * n] = genrandnormal()
+            arr_B[j + i * n] = arr_B[i + j * n]
+
+    for i in range(p):
+        arr_D[i] = float(i + 1)
+
+    # // Obtain an initial iterate
+    # cdef StieVariable StieX = new StieVariable(n, p)
+    StieX = new StieVariable(n, p)
+    StieX.RandInManifold()
+
+    # // Define the Stiefel manifold
+    # cdef Stiefel Domain = Stiefel(n, p)
+    Domain = new Stiefel(n, p)
+
+    # // Define the Brockett problem
+    # cdef StieBrockett Prob = StieBrockett(B, D, n, p)
+    Prob = new StieBrockett(&arr_B[0], &arr_D[0], n, p)
+
+    # // Set the domain of the problem to be the Stiefel manifold
+    Prob.SetDomain(Domain)
+
+    # // output the parameters of the manifold of domain
+    Domain.CheckParams()
+    # // test RTRNewton
+    print("********************************Check RTRNewton*************************************\n")
+	#RTRNewton RTRNewtonsolver = RTRNewton(&Prob, &StieX)
+    RTRNewtonsolver = new RTRNewton(Prob, StieX) #local variables do not need to explicitly typed (as it would be above)
+    # cdef RTRNewton rtrnewton_solver = RTRNewton(&Prob, &StieX)
+	# RTRNewtonsolver.Debug = FINALRESULT
+    RTRNewtonsolver.CheckParams()
+    RTRNewtonsolver.Run()
+
+    # // Check gradient and Hessian
+    # Prob.CheckGradHessian(&StieX)
+    xopt = RTRNewtonsolver.GetXopt()
+
+
+    # return result as numpy array
+    out = np.zeros(n*p)
+    cdef double[::1] arr_out = out
+    xoptptr = xopt.ObtainReadData()
+    for i in range(n*p):
+        arr_out[i] = xoptptr[i]
+
+    del B
+    # very import to rememeber that data is stored in Fortran order
+    result = out.reshape((n,p), order='F')
+    return result

--- a/PythonExamples/libropt.pxd
+++ b/PythonExamples/libropt.pxd
@@ -1,0 +1,72 @@
+
+cdef extern from "randgen.h":
+    void genrandseed(unsigned int s)
+    double genrandnormal()
+
+cdef extern from "SmartSpace.h":
+    cdef cppclass SmartSpace:
+        const double *ObtainReadData()
+
+cdef extern from "Element.h":
+    cdef cppclass Element(SmartSpace):
+        pass
+
+cdef extern from "Manifolds/Stiefel/StieVariable.h":
+    cdef cppclass StieVariable(Element):
+        StieVariable(int n, int p = 1, int num = 1) except +
+        void RandInManifold()
+
+cdef extern from "EucVariable.h":
+    cdef cppclass EucVariable(Element):
+        EucVariable(int r, int l = 1, int n = 1) except +
+        void RandInManifold()
+
+cdef extern from "ProductElement.h":
+    cdef cppclass ProductElement:
+        ProductElement(Element **elements, int numofelements, int *powsinterval, int numoftypes) except +
+        void RandInManifold()
+
+cdef extern from "Manifold.h":
+    cdef cppclass Variable:
+        const double *ObtainReadData()
+
+cdef extern from "Manifold.h":
+    cdef cppclass Manifold:
+        pass
+
+cdef extern from "Stiefel.h":
+    cdef cppclass Stiefel(Manifold):
+        Stiefel(int n, int p) except +
+        void CheckParams()
+
+cdef extern from "Euclidean.h":
+    cdef cppclass Euclidean:
+        Euclidean(int r, int c = 1, int n = 1) except +
+
+cdef extern from "ProductManifold.h":
+    cdef cppclass ProductManifold:
+        ProductManifold(int numberofmanifolds, ...) except +
+
+cdef extern from "Problem.h":
+    cdef cppclass Problem:
+        pass
+
+cdef extern from "StieBrockett.h":
+    cdef cppclass StieBrockett(Problem):
+        StieBrockett(double *inB, double *inD, int inn, int inp)  except +
+        void SetDomain(Manifold *inDomain) except +
+
+
+cdef extern from "Solvers.h":
+    cdef enum DEBUGINFO:
+        NOOUTPUT, FINALRESULT, ITERRESULT, DETAILED, DEBUGLENGTH
+
+
+cdef extern from "RTRNewton.h":
+    cdef cppclass RTRNewton:
+        # RTRNewton(const Problem *prob, const Variable *initialx, const Variable *insoln = NULL) except +
+        RTRNewton(const Problem *prob, const Element *initialx) except +
+        void CheckParams()
+        const Variable *GetXopt()
+        void Run()
+        int Debug

--- a/PythonExamples/setup2.py
+++ b/PythonExamples/setup2.py
@@ -1,0 +1,29 @@
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Distutils import build_ext
+from Cython.Build import cythonize
+
+print("For this compilation to work the following line has to be commented out; #define abs(x) ((x) >= 0 ? (x) : -(x))")
+ext_modules = [Extension("PySimpleExample",
+                     ["PySimpleExample.pyx"],
+                     language='c++',
+                         extra_compile_args=["-std=c++11", "-fPIC"],
+                         extra_link_args=["-std=c++11"],
+                    extra_objects=["libropt.so"], include_dirs=["/home/lucio/mypyprojects/ROPTLIB_2017-02-26",
+                                                                     "/home/lucio/mypyprojects/ROPTLIB_2017-02-26/cwrapper/blas",
+                                                                     "/home/lucio/mypyprojects/ROPTLIB_2017-02-26/cwrapper/lapack",
+                                                                     "/home/lucio/mypyprojects/ROPTLIB_2017-02-26/Manifolds",
+                                                                     "/home/lucio/mypyprojects/ROPTLIB_2017-02-26/Manifolds/Stiefel",
+                                                                     "/home/lucio/mypyprojects/ROPTLIB_2017-02-26/Manifolds/Euclidean",
+                                                                     "/home/lucio/mypyprojects/ROPTLIB_2017-02-26/Problems",
+"/home/lucio/mypyprojects/ROPTLIB_2017-02-26/Solvers",
+                                                                     "/home/lucio/mypyprojects/ROPTLIB_2017-02-26/Problems/StieBrockett",
+                                                                     "/home/lucio/mypyprojects/ROPTLIB_2017-02-26/Others"]
+                     )]
+
+#setup(ext_modules=cythonize("PyManifoldPolLDR.pyx"))
+setup(
+  name = 'PySimpleExample',
+  cmdclass = {'build_ext': build_ext},
+  ext_modules = ext_modules
+)


### PR DESCRIPTION
This option does not require the user to write or compile c++ code, only cython code (although in c++ mode).
This example shows a "main" function (the equivalent of those functions in test folder) written in cython. This function calls existing ROPTLIB objects from cython. The output is a compiled library that the user can then import in python.